### PR TITLE
Application should exit if GenerateTLSConfig errors

### DIFF
--- a/app/kube_client.go
+++ b/app/kube_client.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 )
 
@@ -45,7 +46,12 @@ type DefaultKubeClient struct {
 //It talks to only one server, and uses configuration of the current context in the
 //given config
 func NewKubeClient(config *Config) KubeClient {
-	tlsConfig, _ := config.GenerateTLSConfig()
+	tlsConfig, err := config.GenerateTLSConfig()
+	if err != nil {
+		fmt.Errorf(err.Error())
+		os.Exit(1)
+	}
+
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
 	}


### PR DESCRIPTION
- Try to handle certs that are relative to the ~/.kube directory
for example in my kubeconfig:

```
users:
- name: cluster
  user:
    client-certificate: cluster-client-cert.pem
    client-key: cluster-client-secret.pem
```

Resolves #6 for me